### PR TITLE
Typing fixups for trigger updating/creation

### DIFF
--- a/functions/internals/trigger_operations.ts
+++ b/functions/internals/trigger_operations.ts
@@ -1,5 +1,10 @@
 import { SlackAPIClient } from "deno-slack-sdk/types.ts";
 import { TriggerEventTypes, TriggerTypes } from "deno-slack-api/mod.ts";
+
+export type TriggerFilter = {
+  statement: string;
+};
+
 export async function findTriggerToUpdate(
   client: SlackAPIClient,
   workflowCallbackId: string,
@@ -34,8 +39,7 @@ export async function createOrUpdateTrigger(
   client: SlackAPIClient,
   workflowCallbackId: string,
   channelIds: string[],
-  // deno-lint-ignore no-explicit-any
-  reactions_filter: any[],
+  reactions_filter: [TriggerFilter, ...TriggerFilter[]],
   triggerToUpdate?: Record<string, string>,
 ) {
   // deno-lint-ignore no-explicit-any

--- a/functions/reaction_trigger.ts
+++ b/functions/reaction_trigger.ts
@@ -2,6 +2,7 @@ import { DefineFunction, SlackFunction } from "deno-slack-sdk/mod.ts";
 import {
   createOrUpdateTrigger,
   findTriggerToUpdate,
+  TriggerFilter,
 } from "./internals/trigger_operations.ts";
 import FAQsDatastore from "../datastores/faqs.ts";
 
@@ -38,8 +39,7 @@ export default SlackFunction(
       return { error };
     }
 
-    // deno-lint-ignore no-explicit-any
-    const reactions_filter: any[] = [];
+    const reactions_filter: TriggerFilter[] = [];
     result.items.forEach((item) => {
       reactions_filter.push(
         { statement: `{{data.reaction}} == ${item.reaction}` },
@@ -60,7 +60,7 @@ export default SlackFunction(
       client,
       workflow_callback_id,
       ["C05CY240HKP"],
-      reactions_filter,
+      reactions_filter as [TriggerFilter, ...TriggerFilter[]], // we tell TS that this array includes _at least_ one defined TriggerFilter using `as`
       triggerToUpdate,
     );
 


### PR DESCRIPTION
Add a TriggerFilter internal type for quick and dirty typing of filters. Assure TypeScript that yes, indeed, at least one TriggerFilter will be provided to the updateOrCreateTrigger method.